### PR TITLE
Fix hanging Mock.Add when timer is not drained

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -183,7 +183,7 @@ func (m *Mock) Timer(d time.Duration) *Timer {
 	defer m.inc(&m.calls.Timer)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	ch := make(chan time.Time)
+	ch := make(chan time.Time, 1)
 	t := &Timer{
 		C:    ch,
 		c:    ch,


### PR DESCRIPTION
When timer channel returned from Mock.After is not listened, the following Mock.Add will hang.
Also fix some issue in unit test.

Sample code
```
package main

import (
        "fmt"
        "sync"
        "time"

        "github.com/facebookgo/clock"
)

func main() {
        mock := clock.NewMock()

        ch := make(chan struct{})
        var wg sync.WaitGroup
        wg.Add(2)
        go func() {
                defer wg.Done()

                select {
                case <-ch:
                case <-mock.After(time.Second):
                }
                fmt.Println("Done")
        }()

        go func() {
                defer wg.Done()
                fmt.Println("Before add time")
                time.Sleep(1 * time.Second)
                mock.Add(1 * time.Second)
                fmt.Println("After add time")
        }()

        _ = ch
        close(ch)

        wg.Wait()
}
```

Sample backtrace
```
goroutine 1 [semacquire]:
sync.runtime_Semacquire(0xc0000140b8)
        /usr/local/go/src/runtime/sema.go:56 +0x39
sync.(*WaitGroup).Wait(0xc0000140b0)
        /usr/local/go/src/sync/waitgroup.go:130 +0x64
main.main()
        /Users/steve/test/src/mockclock/main.go:38 +0x138

goroutine 6 [chan send]:
github.com/facebookgo/clock.(*internalTimer).Tick(0xc00008c100, 0x0, 0xe7791f701, 0x116dd00)
        /Users/steve/gotowork/src/github.com/facebookgo/clock/clock.go:282 +0x9b
github.com/facebookgo/clock.(*Mock).runNextTimer(0xc000088000, 0x0, 0xe7791f701, 0x116dd00, 0x0)
        /Users/steve/gotowork/src/github.com/facebookgo/clock/clock.go:122 +0x15e
github.com/facebookgo/clock.(*Mock).Add(0xc000088000, 0x3b9aca00)
        /Users/steve/gotowork/src/github.com/facebookgo/clock/clock.go:81 +0x9b
main.main.func2(0xc0000140b0, 0xc000088000)
        /Users/steve/test/src/mockclock/main.go:31 +0xaf
created by main.main
        /Users/steve/test/src/mockclock/main.go:27 +0x11c
```